### PR TITLE
Implement chat data retrieval with messages

### DIFF
--- a/controller/ChatController.java
+++ b/controller/ChatController.java
@@ -1,12 +1,16 @@
 package com.practiceproject.linkchat_back.controller;
 
+import com.practiceproject.linkchat_back.model.ChatInfo;
+import com.practiceproject.linkchat_back.repository.ChatMessageRepository;
+import com.practiceproject.linkchat_back.repository.ChatRepository;
+import com.practiceproject.linkchat_back.repository.ChatUserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -14,20 +18,26 @@ import java.util.Map;
 public class ChatController {
     private static final Logger logger = LoggerFactory.getLogger(ChatController.class);
 
-    @GetMapping
-    public Map<String, Object> getChatData() {
-        logger.debug("Fetching chat data");
+    private final ChatRepository chatRepository;
+    private final ChatUserRepository chatUserRepository;
+    private final ChatMessageRepository chatMessageRepository;
+
+    public ChatController(ChatRepository chatRepository,
+                          ChatUserRepository chatUserRepository,
+                          ChatMessageRepository chatMessageRepository) {
+        this.chatRepository = chatRepository;
+        this.chatUserRepository = chatUserRepository;
+        this.chatMessageRepository = chatMessageRepository;
+    }
+
+    @GetMapping("/{chatId}")
+    public Map<String, Object> getChatData(@PathVariable("chatId") long chatId) {
+        logger.debug("Fetching chat data for {}", chatId);
+        ChatInfo info = new ChatInfo(chatId, chatRepository, chatUserRepository, chatMessageRepository);
         return Map.of(
-                "title", "This is our chat",
-                "users", List.of(
-                        Map.of("name", "Eugen", "status", "online"),
-                        Map.of("name", "John", "status", "offline")
-                ),
-                "messages", List.of(
-                        Map.of("sender", "Eugen", "content", "Hello everyone!", "timestamp", "2023-10-01T12:00:00"),
-                        Map.of("sender", "John", "content", "Hi Eugen!", "timestamp", "2023-10-01T12:01:00")
-                ),
-                "settings", Map.of("createdAt", "2023-10-01T12:00:00")
+                "title", info.getTitle(),
+                "users", info.getUsers(),
+                "messages", info.getMessages()
         );
     }
 }

--- a/model/Chat.java
+++ b/model/Chat.java
@@ -1,0 +1,42 @@
+package com.practiceproject.linkchat_back.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "chat")
+public class Chat {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chat_id")
+    private Long chatId;
+
+    private String title;
+
+    private String users; // optional string column as per DB schema
+
+    public Chat() {}
+
+    public Long getChatId() {
+        return chatId;
+    }
+
+    public void setChatId(Long chatId) {
+        this.chatId = chatId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getUsers() {
+        return users;
+    }
+
+    public void setUsers(String users) {
+        this.users = users;
+    }
+}

--- a/model/ChatInfo.java
+++ b/model/ChatInfo.java
@@ -1,25 +1,55 @@
 package com.practiceproject.linkchat_back.model;
 
+import com.practiceproject.linkchat_back.repository.ChatMessageRepository;
+import com.practiceproject.linkchat_back.repository.ChatRepository;
+import com.practiceproject.linkchat_back.repository.ChatUserRepository;
+
 import java.util.ArrayList;
 import java.util.List;
-import com.practiceproject.linkchat_back.model.Message;
 
 public class ChatInfo {
     private String title;
     private List<User> users;
-    private List<Message> messages;
-
-    //new chat
-    // existing chat
+    private List<ChatMessage> messages;
 
     public ChatInfo(String title) {
-        //Create new chat using the title
         this.title = title;
         this.users = new ArrayList<>();
         this.messages = new ArrayList<>();
     }
-    public String ChatInfo( long chatId) {
-        this.messages = MeessageRepository.getMessagesByChatId(chatId);
 
+    public ChatInfo(long chatId,
+                    ChatRepository chatRepository,
+                    ChatUserRepository chatUserRepository,
+                    ChatMessageRepository messageRepository) {
+        this.title = chatRepository.findById(chatId)
+                .map(Chat::getTitle)
+                .orElse(null);
+        this.users = chatUserRepository.getChatUsers(chatId);
+        this.messages = messageRepository.getMessagesByChatId(chatId);
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public List<User> getUsers() {
+        return users;
+    }
+
+    public void setUsers(List<User> users) {
+        this.users = users;
+    }
+
+    public List<ChatMessage> getMessages() {
+        return messages;
+    }
+
+    public void setMessages(List<ChatMessage> messages) {
+        this.messages = messages;
     }
 }

--- a/model/ChatMessage.java
+++ b/model/ChatMessage.java
@@ -1,0 +1,73 @@
+package com.practiceproject.linkchat_back.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "messages")
+public class ChatMessage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "message_id")
+    private Long messageId;
+
+    @Column(name = "message_text")
+    private String messageText;
+
+    private String timestamp;
+    private String sender;
+    private String recipient;
+
+    @ManyToOne
+    @JoinColumn(name = "chat_id")
+    private Chat chat;
+
+    public ChatMessage() {}
+
+    public Long getMessageId() {
+        return messageId;
+    }
+
+    public void setMessageId(Long messageId) {
+        this.messageId = messageId;
+    }
+
+    public String getMessageText() {
+        return messageText;
+    }
+
+    public void setMessageText(String messageText) {
+        this.messageText = messageText;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getSender() {
+        return sender;
+    }
+
+    public void setSender(String sender) {
+        this.sender = sender;
+    }
+
+    public String getRecipient() {
+        return recipient;
+    }
+
+    public void setRecipient(String recipient) {
+        this.recipient = recipient;
+    }
+
+    public Chat getChat() {
+        return chat;
+    }
+
+    public void setChat(Chat chat) {
+        this.chat = chat;
+    }
+}

--- a/model/ChatUser.java
+++ b/model/ChatUser.java
@@ -1,0 +1,45 @@
+package com.practiceproject.linkchat_back.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "chat_users")
+public class ChatUser {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "chat_id", nullable = false)
+    private Chat chat;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public ChatUser() {}
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Chat getChat() {
+        return chat;
+    }
+
+    public void setChat(Chat chat) {
+        this.chat = chat;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+}

--- a/repository/ChatMessageRepository.java
+++ b/repository/ChatMessageRepository.java
@@ -1,0 +1,13 @@
+package com.practiceproject.linkchat_back.repository;
+
+import com.practiceproject.linkchat_back.model.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+    @Query("select m from ChatMessage m where m.chat.chatId = :chatId")
+    List<ChatMessage> getMessagesByChatId(@Param("chatId") long chatId);
+}

--- a/repository/ChatRepository.java
+++ b/repository/ChatRepository.java
@@ -1,0 +1,7 @@
+package com.practiceproject.linkchat_back.repository;
+
+import com.practiceproject.linkchat_back.model.Chat;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRepository extends JpaRepository<Chat, Long> {
+}

--- a/repository/ChatUserRepository.java
+++ b/repository/ChatUserRepository.java
@@ -1,0 +1,15 @@
+package com.practiceproject.linkchat_back.repository;
+
+import com.practiceproject.linkchat_back.model.User;
+import com.practiceproject.linkchat_back.model.ChatUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ChatUserRepository extends JpaRepository<ChatUser, Long> {
+
+    @Query("select cu.user from ChatUser cu where cu.chat.chatId = :chatId")
+    List<User> getChatUsers(@Param("chatId") long chatId);
+}


### PR DESCRIPTION
## Summary
- create `ChatMessage` JPA entity for the `messages` table
- add `ChatMessageRepository` with `getMessagesByChatId`
- redesign `ChatInfo` with constructors for new/existing chats
- update `ChatController` to use `ChatInfo`

## Testing
- `mvn -q test` *(fails: command not found)*
- `gradle test` *(fails: project has no Gradle build files)*

------
https://chatgpt.com/codex/tasks/task_e_6848e459d0d083338953e955b7281bca