### PR TITLE
Fix chat endpoint schema for Swagger

### DIFF
--- a/controller/ChatController.java
+++ b/controller/ChatController.java
@@ -31,13 +31,8 @@ public class ChatController {
     }
 
     @GetMapping("/{chatId}")
-    public Map<String, Object> getChatData(@PathVariable("chatId") long chatId) {
+    public ChatInfo getChatData(@PathVariable("chatId") long chatId) {
         logger.debug("Fetching chat data for {}", chatId);
-        ChatInfo info = new ChatInfo(chatId, chatRepository, chatUserRepository, chatMessageRepository);
-        return Map.of(
-                "title", info.getTitle(),
-                "users", info.getUsers(),
-                "messages", info.getMessages()
-        );
+        return new ChatInfo(chatId, chatRepository, chatUserRepository, chatMessageRepository);
     }
 }


### PR DESCRIPTION
## Summary
- return `ChatInfo` directly instead of a generic map

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849dfb97b88833383a8be9867dcf2fd