### PR TITLE
Switch chat API to use chat link

### DIFF
--- a/controller/ChatController.java
+++ b/controller/ChatController.java
@@ -15,8 +15,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Map;
-
 @RestController
 @RequestMapping("/api/chat")
 @Tag(name = "Chat API", description = "Operations related to chat data")
@@ -35,13 +33,13 @@ public class ChatController {
         this.chatMessageRepository = chatMessageRepository;
     }
 
-    @Operation(summary = "Get chat data by chat identifier")
+    @Operation(summary = "Get chat data by chat link")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Chat data retrieved")
     })
-    @GetMapping("/{chatId}")
-    public ChatInfo getChatData(@PathVariable("chatId") long chatId) {
-        logger.debug("Fetching chat data for {}", chatId);
-        return new ChatInfo(chatId, chatRepository, chatUserRepository, chatMessageRepository);
+    @GetMapping("/{link}")
+    public ChatInfo getChatData(@PathVariable("link") String link) {
+        logger.debug("Fetching chat data for {}", link);
+        return new ChatInfo(link, chatRepository, chatUserRepository, chatMessageRepository);
     }
 }

--- a/model/Chat.java
+++ b/model/Chat.java
@@ -14,6 +14,9 @@ public class Chat {
 
     private String users; // optional string column as per DB schema
 
+    @Column(name = "link")
+    private String link;
+
     public Chat() {}
 
     public Long getChatId() {
@@ -38,5 +41,13 @@ public class Chat {
 
     public void setUsers(String users) {
         this.users = users;
+    }
+
+    public String getLink() {
+        return link;
+    }
+
+    public void setLink(String link) {
+        this.link = link;
     }
 }

--- a/model/ChatInfo.java
+++ b/model/ChatInfo.java
@@ -4,6 +4,8 @@ import com.practiceproject.linkchat_back.repository.ChatMessageRepository;
 import com.practiceproject.linkchat_back.repository.ChatRepository;
 import com.practiceproject.linkchat_back.repository.ChatUserRepository;
 
+import com.practiceproject.linkchat_back.model.Chat;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,15 +27,21 @@ public class ChatInfo {
         this.messages = new ArrayList<>();
     }
 
-    public ChatInfo(long chatId,
+    public ChatInfo(String link,
                     ChatRepository chatRepository,
                     ChatUserRepository chatUserRepository,
                     ChatMessageRepository messageRepository) {
-        this.title = chatRepository.findById(chatId)
-                .map(Chat::getTitle)
-                .orElse(null);
-        this.users = chatUserRepository.getChatUsers(chatId);
-        this.messages = messageRepository.getMessagesByChatId(chatId);
+        Chat chat = chatRepository.findByLink(link).orElse(null);
+        if (chat != null) {
+            long chatId = chat.getChatId();
+            this.title = chat.getTitle();
+            this.users = chatUserRepository.getChatUsers(chatId);
+            this.messages = messageRepository.getMessagesByChatId(chatId);
+        } else {
+            this.title = null;
+            this.users = new ArrayList<>();
+            this.messages = new ArrayList<>();
+        }
     }
 
     public String getTitle() {

--- a/repository/ChatRepository.java
+++ b/repository/ChatRepository.java
@@ -3,5 +3,8 @@ package com.practiceproject.linkchat_back.repository;
 import com.practiceproject.linkchat_back.model.Chat;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ChatRepository extends JpaRepository<Chat, Long> {
+    Optional<Chat> findByLink(String link);
 }


### PR DESCRIPTION
## Summary
- add `link` field to `Chat`
- support link lookups in `ChatRepository`
- load chat data via link in `ChatInfo`
- update `/api/chat/{link}` endpoint and swagger docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a4383575c8333977c7356df093337